### PR TITLE
Enable user given datasets

### DIFF
--- a/examples/UCR_alignment.py
+++ b/examples/UCR_alignment.py
@@ -57,7 +57,7 @@ def argparser():
                         help="batch size")
     parser.add_argument('--lr', type=float, default=0.0001,
                         help="learning rate")
-    parser.add_argument('--dpath', type=str, default="data", help="dataset dir path, default examples/data")
+    parser.add_argument('--dpath', type=str, default="", help="dataset dir path, default examples/data")
     args = parser.parse_args()
     return args
 

--- a/examples/UCR_alignment.py
+++ b/examples/UCR_alignment.py
@@ -57,6 +57,7 @@ def argparser():
                         help="batch size")
     parser.add_argument('--lr', type=float, default=0.0001,
                         help="learning rate")
+    parser.add_argument('--dpath', type=str, default="data", help="dataset dir path, default examples/data")
     args = parser.parse_args()
     return args
 
@@ -77,7 +78,7 @@ def run_UCR_alignment(args, dataset_name="ECGFiveDays"):
     print(args)
 
     # Data
-    datadir = "data"
+    datadir = args.dpath #"data/UCR/UCR_TS_Archive_2015"
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     exp_name = f"{dataset_name}_exp"
     # Plotting flag
@@ -101,6 +102,7 @@ def run_UCR_alignment(args, dataset_name="ECGFiveDays"):
 
     DTANargs = Experiment.get_DTAN_args()
     train_loader, validation_loader, test_loader = get_UCR_data(dataset_name=dataset_name,
+                                                                datadir=datadir,
                                                                 batch_size=Experiment.batch_size)
 
 

--- a/helper/UCR_loader.py
+++ b/helper/UCR_loader.py
@@ -96,8 +96,8 @@ def processed_UCR_data(X_train, X_test, y_train, y_test):
 
     # add a third channel for univariate data
     if len(X_train.shape) < 3:
-        X_train = np.expand_dims(X_train, 1)
-        X_test = np.expand_dims(X_test, 1)
+        X_train = np.expand_dims(X_train, -1)
+        X_test = np.expand_dims(X_test, -1)
 
     # Fix labels (some UCR datasets have negative labels)
     class_names = np.unique(y_train, axis=0)

--- a/helper/UCR_loader.py
+++ b/helper/UCR_loader.py
@@ -118,19 +118,22 @@ def processed_UCR_data(X_train, X_test, y_train, y_test):
     return X_train, X_test, y_train, y_test
 
 
-def get_UCR_data(dataset_name, batch_size=32):
+def get_UCR_data(dataset_name, datadir=0, batch_size=32):
     '''
 
     Args:
-        datadir (str): location of data files
         dataset_name (str): name of the dataset under parent dir 'datadir'
+        datadir (str): location of data files
         batch_size (int): batchsize for torch dataloaders
 
     Returns:
 
     '''
 
-    X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset(dataset_name)
+    if (datadir):
+      X_train, X_test, y_train, y_test = load_txt_file(datadir, dataset_name)
+    else:
+      X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset(dataset_name)
     X_train, X_test, y_train, y_test = processed_UCR_data(X_train, X_test, y_train, y_test)
 
     input_shape, n_classes = get_dataset_info(dataset_name, X_train, X_test, y_train, y_test, print_info=True)

--- a/helper/plotting_torch.py
+++ b/helper/plotting_torch.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import torch
 import seaborn as sns
-from helper.UCR_loader import processed_UCR_data
+from helper.UCR_loader import processed_UCR_data, load_txt_file
 from tslearn.datasets import UCR_UEA_datasets
 
 
@@ -119,7 +119,10 @@ def plot_signals(model, device, datadir, dataset_name):
 
     with torch.no_grad():
         # Torch channels first
-        X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset(dataset_name)
+        if (datadir):
+          X_train, X_test, y_train, y_test = load_txt_file(datadir, dataset_name)
+        else:
+          X_train, y_train, X_test, y_test = UCR_UEA_datasets().load_dataset(dataset_name)
         X_train, X_test, y_train, y_test = processed_UCR_data(X_train, X_test, y_train, y_test)
         data =[X_train, X_test]
         labels = [y_train, y_test]

--- a/helper/plotting_torch.py
+++ b/helper/plotting_torch.py
@@ -106,7 +106,7 @@ def plot_mean_signal(X_aligned_within_class, X_within_class, ratio, class_num, d
         plt.tight_layout()
         plot_idx += 1
 
-    #plt.savefig(f'{dataset_name}_{int(class_num)}.pdf', format='pdf')
+    plt.savefig(f'{int(class_num)}_{dataset_name}.pdf', format='pdf')
 
     plt.suptitle(f"{dataset_name}: class-{class_num}", fontsize=title_font+2)
     plt.tight_layout(rect=[0, 0.03, 1, 0.95])


### PR DESCRIPTION
As part of our project "Hip Replacement Motion Analysis", we're working with DTAN, we came across some issues that is fixed by this PR.
The latest version only works with UCR datasets (this was made as part of multichannel fix #8 ), this PR enables running DTAN on user given data and UCR datasets.
It also fixes "Kernel size can’t greater than actual input size" error.